### PR TITLE
Makefiles: help-ify and wildcard-ify

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,18 +1,23 @@
+.DEFAULT_GOAL := help
+
 .PHONY: all
-all: bin/deployer containers
+all: bin/deployer containers ## build everything
 
-bin/deployer:
-	$(MAKE) -C deployer
+bin/deployer: deployer/deployer.bin ## build deployer tool from source
+	mkdir -p bin
+	cp deployer/deployer.bin bin/deployer
+deployer/deployer.bin:
+	$(MAKE) -C deployer deployer.bin
 
-.PHONY: containers
-containers:
-	$(MAKE) -C containers
-
-.PHONY: container
-container:
-	$(MAKE) container -C containers
+.PHONY: container containers
+containers: containers-all ## build all containers # FIXME!
+container: containers-container ## build a container # FIXME!
+containers-%:
+	$(MAKE) -C containers $*
 
 .PHONY: clean
-clean:
+clean: containers-clean ## remove binary artifacts and containers
 	rm -rf bin
-	$(MAKE) clean -C containers
+
+help:
+	@awk -F":.*## " '$$2&&$$1~/^[a-zA-Z_%-]+/{printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}' $(MAKEFILE_LIST)

--- a/containers/Makefile
+++ b/containers/Makefile
@@ -1,3 +1,5 @@
+.DEFAULT_GOAL := help
+
 .PHONY: all
 all:
 	@for NAME in $$(ls); do \
@@ -51,3 +53,6 @@ clean-container: check-env
 	cd "${NAME}" && \
 	rm -rf build && \
 	docker rmi "46bit/${NAME}"
+
+help:
+	@awk -F":.*## " '$$2&&$$1~/^[a-zA-Z_%-]+/{printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}' $(MAKEFILE_LIST)

--- a/deployer/Makefile
+++ b/deployer/Makefile
@@ -1,12 +1,11 @@
-.PHONY: all
-all: build
+.DEFAULT_GOAL := help
 
-.PHONY: build
-build:
-	mkdir -p ../bin
-	go build \
-		-o ../bin/deployer
+.PHONY: all build
+all: build ## build everything
+build: deployer.bin ## build deployer
 
-.PHONY: clean
-clean:
-	rm -f ../bin/deployer
+deployer.bin: ## compile deployer.bin
+	go build -o $@
+
+help:
+	@awk -F":.*## " '$$2&&$$1~/^[a-zA-Z_%-]+/{printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}' $(MAKEFILE_LIST)


### PR DESCRIPTION
This PR:
- adds a help target to 3 Makefiles
- adds an explicit default of that help target
- adds a wildcard target to DRY out a recursive Make